### PR TITLE
Match Tokens / Array Arguments over line breaks

### DIFF
--- a/lib/InlineObjectParser.php
+++ b/lib/InlineObjectParser.php
@@ -235,7 +235,7 @@ class InlineObjectParser
   {
     $typesMatch = implode('|', array_keys($this->_types));
 
-    return '/\[('.$typesMatch.'):(.*?)\]/';
+    return '/\[('.$typesMatch.'):(.*?)\]/s';
   }
 
   /**

--- a/lib/InlineObjectToolkit.php
+++ b/lib/InlineObjectToolkit.php
@@ -34,7 +34,7 @@ class InlineObjectToolkit
       \s*(?:
         (?=\w+\s*=) | \s*$  # followed by another key= or the end of the string
       )
-    /x', $string, $matches, PREG_SET_ORDER);
+    /xs', $string, $matches, PREG_SET_ORDER);
 
     $attributes = array();
     foreach ($matches as $val)


### PR DESCRIPTION
Updates the regex to match over line breaks.  Just adds the newline "s" flag at the end of the toolkit/parser classes.  Don't hate me.
